### PR TITLE
Fix unreachable source.resume()

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,7 +123,7 @@ module.exports = {
 
     stream.addListener('drain', onDrain);
 
-    return source.subscribe(
+    var disposable = source.subscribe(
       function (x) {
         !stream.write(String(x), encoding) && source.pause();
       },
@@ -137,5 +137,7 @@ module.exports = {
       });
 
     source.resume();
+    
+    return disposable;
   }
 };


### PR DESCRIPTION
Since `source.resume()` was after the `return`, it was never called, which meant the values were not being written.
